### PR TITLE
fix: ignoring levels config when putting "false" to useUnbreakableTag

### DIFF
--- a/src/main/java/wutdahack/actuallyunbreaking/mixin/DigDurabilityEnchantmentMixin.java
+++ b/src/main/java/wutdahack/actuallyunbreaking/mixin/DigDurabilityEnchantmentMixin.java
@@ -46,17 +46,23 @@ public abstract class DigDurabilityEnchantmentMixin extends Enchantment {
     private static void makeUnbreakable(ItemStack stack, int level, RandomSource random, CallbackInfoReturnable<Boolean> cir) {
 
         if (!ActuallyUnbreaking.instance.config.useUnbreakableTag) {
-            if (ActuallyUnbreaking.instance.config.useOnlyUnbreakableAtLevel && level == ActuallyUnbreaking.instance.config.onlyUnbreakableAtLevel) {
-                stack.setDamageValue(0); // set item damage to 0 to remove the tool's durability bar
-                cir.setReturnValue(true);
+            if (ActuallyUnbreaking.instance.config.useOnlyUnbreakableAtLevel) {
+                if (level == ActuallyUnbreaking.instance.config.onlyUnbreakableAtLevel) {
+                    stack.setDamageValue(0); // set item damage to 0 to remove the tool's durability bar
+                    cir.setReturnValue(true);
+                }
             }
-            else if (ActuallyUnbreaking.instance.config.useUnbreakableAtLevel && level >= ActuallyUnbreaking.instance.config.unbreakableAtLevel) {
-                stack.setDamageValue(0);
-                cir.setReturnValue(true);
+            else if (ActuallyUnbreaking.instance.config.useUnbreakableAtLevel) {
+                if (level >= ActuallyUnbreaking.instance.config.unbreakableAtLevel) {
+                    stack.setDamageValue(0);
+                    cir.setReturnValue(true);
+                }
             }
-            else if (ActuallyUnbreaking.instance.config.maxLevelOnly && level >= Enchantments.UNBREAKING.getMaxLevel()) {
-                stack.setDamageValue(0);
-                cir.setReturnValue(true);
+            else if (ActuallyUnbreaking.instance.config.maxLevelOnly) {
+                if (level >= Enchantments.UNBREAKING.getMaxLevel()) {
+                    stack.setDamageValue(0);
+                    cir.setReturnValue(true);
+                }
             }
             else if (level > 0) {
                 stack.setDamageValue(0);


### PR DESCRIPTION
When putting the option "useUnbreakableTag" at "false", the last else was always returning true when any Unbreaking enchantement level was present, because the previous conditions were not separated correctly.